### PR TITLE
Fix crash with Dramatic Doors by adjusting LockableDoor.

### DIFF
--- a/rawsrc/1.20.1/xtrablock/LockableDoor.java
+++ b/rawsrc/1.20.1/xtrablock/LockableDoor.java
@@ -126,7 +126,8 @@ public class LockableDoor extends DoorBlock {
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> p_52803_) {
-        p_52803_.add(HALF, FACING, OPEN, HINGE, POWERED,LOCKED);
+        super.createBlockStateDefinition(p_52803_);
+        p_52803_.add(LOCKED);
     }
 
     // copied only to allow LOCKED property to pass through hinge check that original block requires to function


### PR DESCRIPTION
This will change how the block state definition is declared for LockableDoor to properly use super. 

It's a very easy fix. 

The change will allow for this to happen as the door will properly inherit waterlogged property injected into base door block.

![2024-06-20_06 44 33](https://github.com/roberttkahelin8/thingmajigs/assets/5838739/94c298bc-6882-4a93-8578-652a69003f24)

This will fix https://github.com/roberttkahelin8/thingmajigs/issues/10